### PR TITLE
drop PWP::Encoding dependency

### DIFF
--- a/weaver.ini
+++ b/weaver.ini
@@ -1,7 +1,4 @@
 [@Default]
 
-[-Encoding]
-encoding = utf8
-
 [-Transformer]
 transformer = List


### PR DESCRIPTION
This is the same as [previous one](https://github.com/creaktive/Dist-Zilla-MintingProfile-SYP/pull/1).
Do I get it right, that `MintingProfile` is only for bootstrapping new dists, so that even if this `Encoding` plugin was removed from it, it should be manually removed from other dists, which were started before the `MintingProfile` was updated?

If it is so, and you do not object the idea, I'm ready to submit patches -- this is what my [quest](https://questhub.io/realm/perl/quest/5277f3cc9f567ad56f0000e7) is about anyway :)
