### PR TITLE
 add test into xt/author/, and inject a prereq on Test::Mojibake

### DIFF
--- a/lib/Dist/Zilla/Plugin/MojibakeTests.pm
+++ b/lib/Dist/Zilla/Plugin/MojibakeTests.pm
@@ -8,6 +8,18 @@ use warnings qw(all);
 
 use Moose;
 extends q(Dist::Zilla::Plugin::InlineFiles);
+with 'Dist::Zilla::Role::PrereqSource';
+
+sub register_prereqs {
+    my $self = shift;
+    $self->zilla->register_prereqs(
+        {
+            type  => 'requires',
+            phase => 'develop',
+        },
+        'Test::Mojibake' => 0,
+    );
+}
 
 __PACKAGE__->meta->make_immutable;
 no Moose;
@@ -41,9 +53,6 @@ use strict;
 use warnings qw(all);
 
 use Test::More;
-
-## no critic (ProhibitStringyEval, RequireCheckingReturnValueOfEval)
-eval q(use Test::Mojibake);
-plan skip_all => q(Test::Mojibake required for source encoding testing) if $@;
+use Test::Mojibake;
 
 all_files_encoding_ok();

--- a/lib/Dist/Zilla/Plugin/MojibakeTests.pm
+++ b/lib/Dist/Zilla/Plugin/MojibakeTests.pm
@@ -1,5 +1,5 @@
 package Dist::Zilla::Plugin::MojibakeTests;
-# ABSTRACT: Release tests for source encoding
+# ABSTRACT: Author tests for source encoding
 
 use strict;
 use warnings qw(all);
@@ -26,7 +26,7 @@ In F<dist.ini>:
 
 This is an extension of L<Dist::Zilla::Plugin::InlineFiles>, providing the following file:
 
-    xt/release/mojibake.t - a standard Test::Mojibake test
+    xt/author/mojibake.t - a standard Test::Mojibake test
 
 =for test_synopsis 1;
 __END__
@@ -34,7 +34,7 @@ __END__
 =cut
 
 __DATA__
-___[ xt/release/mojibake.t ]___
+___[ xt/author/mojibake.t ]___
 #!perl
 
 use strict;


### PR DESCRIPTION
We expect this test to pass on every commit, not just at release: see http://blog.urth.org/2015/06/28/author-versus-release-tests-with-and-without-distzilla/

Also, the test has been changed to require Test::Mojibake, and this is injected as a develop prereq into the dist being built.
