### PR TITLE
remove direct dependency on Test::Mojibake

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -43,12 +43,6 @@ move                = README.pod
 
 [AutoPrereqs]
 
-[Prereqs]
-Test::Mojibake      = 0
-
-[Prereqs / RuntimeRecommends]
-Unicode::CheckUTF8  = 0
-
 [MinimumPerl]
 perl                = 5.008
 


### PR DESCRIPTION
This plugin doesn't use Test::Mojibake, but generates a test that uses it. Building a dist using this plugin doesn't need Test::Mojibake for anything, and is an extraneous dependency if you don't intent to run the test, or are running it on a different system.

Unicode::CheckUTF8 is only indirectly used via Test::Mojibake, so it can be removed as well.